### PR TITLE
Initial glossary

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,12 @@
+# Glossary
+
+| Term | Description |
+| --- | --- |
+| **CID** | **Configured IED Description**. This SCL file contains the device-specific data for the configuration of an IED. |
+|**ICD** | **IED Capability Description**. This SCL file contains the description of the complete capabilities of an IED as well as the associated logical nodes and data types. |
+|**IID** | **Instantiated IED Description**. This SCL file contains the instantiated configuration of an IED returned by an IED configurator. |
+|**SCD**| **System Configuration Description**. This SCL file contains the description of the complete substation automation system (single line diagram and logical node representation of functionalities, communication network, IED functions and configurations). |
+|**SCL**| The **System Configuration description Language** is the language specified by the IEC 61850 standard for the configuration of devices in the power substation. It aims at ensuring the functional interoperability between equipment from a system perspective by defining object models for the devices and for their interrelated functions. SCL is defined in IEC 61850 Part 6. It includes several types of files: SSD, SCD, ICD, CID, IID, SED. *(cf. https://en.wikipedia.org/wiki/Substation_Configuration_Language)* |
+|**SED**| **System Exchange Description**. This SCL file contains the description of the communication interface between two systems (two substations). |
+|**SSD**| **System Specification Description**. This SCL file contains the description of the substation automation system based on a single line diagram and a logical node representation of functionalities. |
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Interested in contributing? Please read carefully the [CONTRIBUTING guidelines](https://github.com/com-pas/contributing/blob/master/CONTRIBUTING.md).
 
+Refer to [GLOSSARY](/GLOSSARY.md) for technical terms and acronyms.
 
 ## Functional architecture
 


### PR DESCRIPTION
Creating initial glossary explaining SCL type acronyms.
Second try with proper sign-off.