### PR TITLE
chore: opt out of allstar in this repo

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,2 @@
+optConfig:
+  optOut: true

--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Alliander N.V.
+#
+# SPDX-License-Identifier: CC-BY-4.0
 optConfig:
   optOut: true


### PR DESCRIPTION
Closes #184 

CoMPAS Architecture only holds markdown files, for that reason a SECURITY.md makes no sense since we don't have versions or dependencies to secure 
